### PR TITLE
Fixed references to qiniu/api in project to qiniu/api.v6

### DIFF
--- a/.gopmfile
+++ b/.gopmfile
@@ -2,18 +2,18 @@
 path = github.com/gpmgo/switch
 
 [deps]
-github.com/Unknwon/com = 
-github.com/Unknwon/goconfig = 
-github.com/Unknwon/i18n = 
-github.com/Unknwon/macaron = 
-github.com/go-sql-driver/mysql = 
-github.com/go-xorm/xorm = 
-github.com/macaron-contrib/cache = 
-github.com/macaron-contrib/i18n = 
-github.com/macaron-contrib/session = 
-github.com/macaron-contrib/toolbox = 
-github.com/qiniu/api = 
-gopkg.in/go-fsnotify/fsnotify.v1 = 
+github.com/Unknwon/com =
+github.com/Unknwon/goconfig =
+github.com/Unknwon/i18n =
+github.com/Unknwon/macaron =
+github.com/go-sql-driver/mysql =
+github.com/go-xorm/xorm =
+github.com/macaron-contrib/cache =
+github.com/macaron-contrib/i18n =
+github.com/macaron-contrib/session =
+github.com/macaron-contrib/toolbox =
+github.com/qiniu/api.v6 =
+gopkg.in/go-fsnotify/fsnotify.v1 =
 
 [res]
 include = templates|public|conf

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -16,15 +16,15 @@ USER = root
 PASSWD =
 
 [github]
-CLIENT_ID = 
-CLIENT_SECRET = 
+CLIENT_ID =
+CLIENT_SECRET =
 
 [qiniu]
-UP_HOST = 
+UP_HOST =
 BUCKET_NAME =
-BUCKET_URL =  
-ACCESS_KEY = 
-SECRET_KEY = 
+BUCKET_URL =
+ACCESS_KEY =
+SECRET_KEY =
 
 [i18n]
 LANGS = en-US,zh-CN
@@ -32,4 +32,4 @@ NAMES = English,简体中文
 REDIRECT = true
 
 [admin]
-ACCESS_TOKEN = 
+ACCESS_TOKEN =

--- a/modules/qiniu/qiniu.go
+++ b/modules/qiniu/qiniu.go
@@ -3,8 +3,8 @@ package qiniu
 import (
 	"strings"
 
-	"github.com/qiniu/api/io"
-	"github.com/qiniu/api/rs"
+	"github.com/qiniu/api.v6/io"
+	"github.com/qiniu/api.v6/rs"
 
 	"github.com/gpmgo/switch/modules/setting"
 )

--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/Unknwon/com"
 	"github.com/Unknwon/macaron"
-	"github.com/qiniu/api/conf"
+	"github.com/qiniu/api.v6/conf"
 	"gopkg.in/ini.v1"
 
 	"github.com/gpmgo/switch/modules/log"


### PR DESCRIPTION
For whatever reason the developer at https://github.com/qiniu/api removed all the files and recreated them at https://github.com/qiniu/api.v6 and https://github.com/qiniu/api.v7

This caused switch to stop running so I just added the api.v6 to all the locations and tested with 

gopm run switch.go and everything works.
